### PR TITLE
Remove warning pop-up in SUM/SRUM Repair scripts

### DIFF
--- a/KAPE/SRUM-Repair.ps1
+++ b/KAPE/SRUM-Repair.ps1
@@ -128,7 +128,7 @@ Set-Location -Path $OutputPath
 Start-Process -Wait -NoNewWindow "esentutl.exe" -argumentlist "/r sru /i"
 
 # Execute this command esentutl.exe /p SRUDB.dat
-$Prog = Start-Process -NoNewWindow "esentutl.exe" -argumentlist "/p $OutputPath\SRUDB.dat" -PassThru
+$Prog = Start-Process -NoNewWindow "esentutl.exe" -argumentlist "/p $OutputPath\SRUDB.dat /o" -PassThru
 $count = 0
 $window = $false
 $wshell = New-Object -ComObject wscript.shell;

--- a/KAPE/SUM-Repair.ps1
+++ b/KAPE/SUM-Repair.ps1
@@ -105,8 +105,8 @@ Get-ChildItem $workingSUM -Recurse | ForEach-Object {
 }
 
 # Execute this command esentutl.exe /p Current.mdb
-Write-Host (Get-Date).ToString() "| Running esentutl.exe -argumentlist /p $workingSUM\Current.mdb -PassThru"
-$currentProg = Start-Process -NoNewWindow "esentutl.exe" -argumentlist "/p $workingSUM\Current.mdb" -PassThru
+Write-Host (Get-Date).ToString() "| Running esentutl.exe -argumentlist /p $workingSUM\Current.mdb /o -PassThru"
+$currentProg = Start-Process -NoNewWindow "esentutl.exe" -argumentlist "/p $workingSUM\Current.mdb /o" -PassThru
 $count = 0
 $window = $false
 $wshell = New-Object -ComObject wscript.shell;
@@ -125,8 +125,8 @@ do { Start-Sleep 1 }
 while (Get-Process -Id $currentProg.Id -Ea SilentlyContinue)
 
 # Execute this command esentutl.exe /p SystemIdentity.mdb
-Write-Host (Get-Date).ToString() "| Running esentutl.exe -argumentlist /p $workingSUM\SystemIdentity.mdb -PassThru"
-$siProg = Start-Process -NoNewWindow "esentutl.exe" -argumentlist "/p $workingSUM\SystemIdentity.mdb" -PassThru
+Write-Host (Get-Date).ToString() "| Running esentutl.exe -argumentlist /p $workingSUM\SystemIdentity.mdb /o -PassThru"
+$siProg = Start-Process -NoNewWindow "esentutl.exe" -argumentlist "/p $workingSUM\SystemIdentity.mdb /o" -PassThru
 $count = 0
 $window = $false
 $wshell = New-Object -ComObject wscript.shell;
@@ -147,8 +147,8 @@ while (Get-Process -Id $siProg.Id -Ea SilentlyContinue)
 # For each file found
 Get-ChildItem | Where-Object { $_.Name -match '^(\{[-A-Z0-9]+?\})\.mdb' } | ForEach-Object{
 	# Execute this command esentutl.exe /p "{<GUID>}.mdb"
-	Write-Host (Get-Date).ToString() "| Running esentutl.exe -argumentlist /p $workingSUM\$_ -PassThru"
-	$Prog = Start-Process -NoNewWindow "esentutl.exe" -argumentlist "/p $workingSUM\$_" -PassThru
+	Write-Host (Get-Date).ToString() "| Running esentutl.exe -argumentlist /p $workingSUM\$_ /o -PassThru"
+	$Prog = Start-Process -NoNewWindow "esentutl.exe" -argumentlist "/p $workingSUM\$_ /o" -PassThru
 	$count = 0
 	$window = $false
 	$wshell = New-Object -ComObject wscript.shell;


### PR DESCRIPTION
Hello Andrew, we have identified that a warning pop-up can occur while running SUM and SRUM repair scripts in Kape.

We encountered an issue where the SUM and SRUM repair scripts would pause Kape, waiting for user input.

<img width="408" height="188" alt="image" src="https://github.com/user-attachments/assets/364813c7-3107-4c24-b456-089bfcace521" />


In my understanding, the warning originates from Esentutl.
> Repair does not run database recovery. If a database is in “Dirty Shutdown” state, it is strongly recommended that before proceeding with repairs, recovery is first run to properly complete database operations for the previous shutdown.
> The /g option pauses the utility for user input before repair is performed if corruption is detected. This option overrides the /o option.
https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/hh875504(v=ws.11)

To resolve this, we added the '/o' option, which appears to suppress the warning and allows the scripts to run smoothly.
We also compared the script output with and without this change: the headers in the CSV files remain identical.